### PR TITLE
Add product grouping by categories functionality

### DIFF
--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/application/service/ProductService.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/application/service/ProductService.java
@@ -1,11 +1,13 @@
 package io.github.juniorcorzo.UrbanStyle.application.service;
 
+import io.github.juniorcorzo.UrbanStyle.domain.dtos.ProductAggregationDomain;
 import io.github.juniorcorzo.UrbanStyle.domain.entities.ProductEntity;
 import io.github.juniorcorzo.UrbanStyle.domain.repository.ProductsRepository;
 import io.github.juniorcorzo.UrbanStyle.infrastructure.adapter.dtos.common.ProductDTO;
 import io.github.juniorcorzo.UrbanStyle.infrastructure.adapter.dtos.request.ProductImagesDTO;
 import io.github.juniorcorzo.UrbanStyle.infrastructure.adapter.dtos.response.ResponseDTO;
 import io.github.juniorcorzo.UrbanStyle.infrastructure.adapter.mapper.ProductMapper;
+import org.apache.catalina.connector.Response;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -49,6 +51,10 @@ public class ProductService {
                 List.of(this.productMapper.toDTO(productResponse)),
                 "Product retrieved successfully"
         );
+    }
+
+    public ResponseDTO<ProductAggregationDomain> groupProductsByCategories(){
+        return new ResponseDTO<>(HttpStatus.OK, this.productsRepository.groupAllByCategories(), "Product retrieved successfully");
     }
 
     public ResponseDTO<ProductDTO> getProductsByCategory(String categoryId) {

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/domain/dtos/ProductAggregationDomain.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/domain/dtos/ProductAggregationDomain.java
@@ -1,0 +1,11 @@
+package io.github.juniorcorzo.UrbanStyle.domain.dtos;
+
+import io.github.juniorcorzo.UrbanStyle.infrastructure.adapter.dtos.common.ProductDTO;
+
+import java.util.List;
+
+public record ProductAggregationDomain(
+        String categories,
+        List<ProductDTO> products
+) {
+}

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/domain/entities/ProductEntity.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/domain/entities/ProductEntity.java
@@ -1,6 +1,10 @@
 package io.github.juniorcorzo.UrbanStyle.domain.entities;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.index.TextIndexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.MongoId;
 
@@ -14,11 +18,14 @@ import java.util.List;
 public class ProductEntity {
     @MongoId
     private String id;
+    @TextIndexed
     private String name;
+    @TextIndexed
     private String description;
     private double price;
     private double discount;
     private List<String> images;
+    @TextIndexed
     private String[] categories;
     private Attribute attributes;
     private int stock;

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/domain/repository/ProductsRepository.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/domain/repository/ProductsRepository.java
@@ -1,6 +1,8 @@
 package io.github.juniorcorzo.UrbanStyle.domain.repository;
 
+import io.github.juniorcorzo.UrbanStyle.domain.dtos.ProductAggregationDomain;
 import io.github.juniorcorzo.UrbanStyle.domain.entities.ProductEntity;
+import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.DeleteQuery;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.Update;
@@ -9,6 +11,13 @@ import org.springframework.data.repository.ListCrudRepository;
 import java.util.List;
 
 public interface ProductsRepository extends ListCrudRepository<ProductEntity, String> {
+
+    @Aggregation(pipeline = {
+            "{ '$unwind': '$categories' }",
+            "{ '$group': { _id: '$categories', products: { $push: '$$ROOT' } } }",
+            "{ '$project': { categories: '$_id', products: 1, _id: 0 } }"
+    })
+    List<ProductAggregationDomain> groupAllByCategories();
 
     @Query("{ '$text': { '$search': '?0'} }")
     List<ProductEntity> searchProducts(String search);

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/infrastructure/controller/ProductController.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/infrastructure/controller/ProductController.java
@@ -1,6 +1,7 @@
 package io.github.juniorcorzo.UrbanStyle.infrastructure.controller;
 
 import io.github.juniorcorzo.UrbanStyle.application.service.ProductService;
+import io.github.juniorcorzo.UrbanStyle.domain.dtos.ProductAggregationDomain;
 import io.github.juniorcorzo.UrbanStyle.infrastructure.adapter.dtos.common.ProductDTO;
 import io.github.juniorcorzo.UrbanStyle.infrastructure.adapter.dtos.request.ProductImagesDTO;
 import io.github.juniorcorzo.UrbanStyle.infrastructure.adapter.dtos.response.ResponseDTO;
@@ -26,6 +27,11 @@ public class ProductController {
     @GetMapping
     public ResponseDTO<ProductDTO> getProductById(@RequestParam String id) {
         return productService.getProductById(id);
+    }
+
+    @GetMapping("/group")
+    public ResponseDTO<ProductAggregationDomain> groupProductsByCategories(){
+        return this.productService.groupProductsByCategories();
     }
 
     @GetMapping("/{category}")


### PR DESCRIPTION
Introduce a new `groupProductsByCategories` feature in the service, controller, and repository layers. This includes a MongoDB aggregation pipeline to group products by categories and relevant DTOs for domain representation. Additional indexing added to `ProductEntity` for improved querying.