### PR TITLE
Add endpoints and logic for most sold products and categories

### DIFF
--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/application/service/OrderService.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/application/service/OrderService.java
@@ -1,6 +1,7 @@
 package io.github.juniorcorzo.UrbanStyle.application.service;
 
 import io.github.juniorcorzo.UrbanStyle.domain.dtos.OrderHistory;
+import io.github.juniorcorzo.UrbanStyle.domain.dtos.SalesRecord;
 import io.github.juniorcorzo.UrbanStyle.domain.entities.OrdersEntity;
 import io.github.juniorcorzo.UrbanStyle.domain.enums.OrderStatus;
 import io.github.juniorcorzo.UrbanStyle.domain.repository.OrderRepository;
@@ -27,6 +28,23 @@ public class OrderService {
                 allOrders,
                 "Orders retrieved successfully"
         );
+    }
+
+    public ResponseDTO<SalesRecord> getProductsMoreSold() {
+        return new ResponseDTO<>(
+                HttpStatus.OK,
+                this.orderRepository.findProductsMoreSold(),
+                "Orders retrieved successfully"
+        );
+    }
+
+    public ResponseDTO<SalesRecord> getCategoryMoreSold() {
+        return new ResponseDTO<>(
+                HttpStatus.OK,
+                this.orderRepository.findCategoriesMoreSold(),
+                "Orders retrieved successfully"
+        );
+
     }
 
     public ResponseDTO<OrdersDTO> getOrdersByUserId(String userId) {

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/domain/dtos/SalesRecord.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/domain/dtos/SalesRecord.java
@@ -1,0 +1,7 @@
+package io.github.juniorcorzo.UrbanStyle.domain.dtos;
+
+public record SalesRecord(
+        String name,
+        int sold
+) {
+}

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/domain/entities/OrdersEntity.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/domain/entities/OrdersEntity.java
@@ -14,7 +14,7 @@ import org.springframework.data.mongodb.core.mapping.MongoId;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Document("Orders")
+@Document("orders")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/domain/repository/OrderRepository.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/domain/repository/OrderRepository.java
@@ -1,7 +1,9 @@
 package io.github.juniorcorzo.UrbanStyle.domain.repository;
 
 import io.github.juniorcorzo.UrbanStyle.domain.dtos.OrderHistory;
+import io.github.juniorcorzo.UrbanStyle.domain.dtos.SalesRecord;
 import io.github.juniorcorzo.UrbanStyle.domain.entities.OrdersEntity;
+import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.Update;
 import org.springframework.data.repository.ListCrudRepository;
@@ -13,6 +15,29 @@ import java.util.List;
 public interface OrderRepository extends ListCrudRepository<OrdersEntity, String> {
     @Query("{ 'userId': ?0 }")
     List<OrdersEntity> findAllOrdersByUserId(String userId);
+
+    @Aggregation(pipeline = {
+            "{ '$unwind': '$products' }",
+            "{ '$group': { _id: '$products.name', 'sold': { $sum: '$products.quantity' } } }",
+            "{ '$project': { '_id': 0, 'sold': 1, name: '$_id' } }",
+            "{ '$sort': { sold: -1 } }",
+            "{ $limit: 10 }"
+    })
+    List<SalesRecord> findProductsMoreSold();
+
+    @Aggregation(
+            pipeline = {
+                    "{ $unwind: '$products' }",
+                    "{ $lookup: { from: 'products', localField: 'products.productId', foreignField: '_id', as: 'product_info' } }",
+                    "{ $unwind: { path: '$product_info' } }",
+                    "{ $unwind: { path: '$product_info.categories' } }",
+                    "{ $group: { _id:  '$product_info.categories', sold: { $sum: 1 } } }",
+                    "{ $project: { _id: 0, name: '$_id', sold: 1 } }",
+                    "{ $sort: { sold: -1 } }",
+                    "{ $limit: 10 }"
+            }
+    )
+    List<SalesRecord> findCategoriesMoreSold();
 
     @Query("{ '_id': ?0 }")
     @Update("{ '$set': { 'status': ?1}, '$push': { 'history': ?2 } }")

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/infrastructure/controller/OrderController.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/infrastructure/controller/OrderController.java
@@ -1,6 +1,7 @@
 package io.github.juniorcorzo.UrbanStyle.infrastructure.controller;
 
 import io.github.juniorcorzo.UrbanStyle.application.service.OrderService;
+import io.github.juniorcorzo.UrbanStyle.domain.dtos.SalesRecord;
 import io.github.juniorcorzo.UrbanStyle.domain.enums.OrderStatus;
 import io.github.juniorcorzo.UrbanStyle.infrastructure.adapter.dtos.common.OrdersDTO;
 import io.github.juniorcorzo.UrbanStyle.infrastructure.adapter.dtos.response.ResponseDTO;
@@ -21,6 +22,16 @@ public class OrderController {
     @GetMapping("/by")
     public ResponseDTO<OrdersDTO> getOrdersByUserId(@RequestParam("user-id") String userId) {
         return this.orderService.getOrdersByUserId(userId);
+    }
+
+    @GetMapping("/products-most-sold")
+    public ResponseDTO<SalesRecord> getProductsMoreSold() {
+        return this.orderService.getProductsMoreSold();
+    }
+
+    @GetMapping("/categories-most-sold")
+    public ResponseDTO<SalesRecord> getCategoryMoreSold() {
+        return this.orderService.getCategoryMoreSold();
     }
 
     @PostMapping("/create")


### PR DESCRIPTION
Implemented two new endpoints in `OrderController` to fetch the most sold products and categories. Added corresponding repository queries with MongoDB aggregations and a `SalesRecord` DTO to structure the response data. Updated service methods to integrate these functionalities.