### PR TITLE
feat(reports): Display data in most sold tables

### DIFF
--- a/Frontend/urban-style/src/lib/mediators/category-table.mediator.tsx
+++ b/Frontend/urban-style/src/lib/mediators/category-table.mediator.tsx
@@ -43,9 +43,11 @@ async function categoriesMoreSold() {
 	const columns = [
 		columnAccessor.accessor('name', {
 			header: 'Categoría',
+			cell: ({ getValue }) => <Cell.Span>{getValue()}</Cell.Span>,
 		}),
 		columnAccessor.accessor('sold', {
 			header: 'Vendido',
+			cell: ({ getValue }) => <Cell.Span>{getValue()}</Cell.Span>,
 		}),
 	] as ColumnDef<unknown, any>[]
 

--- a/Frontend/urban-style/src/lib/mediators/product-table.mediator.tsx
+++ b/Frontend/urban-style/src/lib/mediators/product-table.mediator.tsx
@@ -108,9 +108,11 @@ async function mostSoldTable() {
 	const columns = [
 		columnAccessor.accessor('name', {
 			header: 'Producto',
+			cell: ({ getValue }) => <Cell.Span>{getValue()}</Cell.Span>,
 		}),
 		columnAccessor.accessor('sold', {
 			header: 'Vendido',
+			cell: ({ getValue }) => <Cell.Span>{getValue()}</Cell.Span>,
 		}),
 	] as ColumnDef<unknown, any>[]
 


### PR DESCRIPTION
The "Most Sold Products" and "Most Sold Categories" tables were not displaying data in their cells. This was due to the missing `cell` render function in the column definitions for `@tanstack/react-table`.

This commit adds the necessary `cell` property to the `name` and `sold` columns for both tables, ensuring that the product/category names and their sold counts are correctly rendered.