### PR TITLE
feat(docker): add production-ready Docker setup for backend, frontend…

### DIFF
--- a/Backend/UrbanStyle/Dockerfile
+++ b/Backend/UrbanStyle/Dockerfile
@@ -2,49 +2,34 @@
 FROM gradle:8.14.2-jdk21-alpine AS builder
 LABEL authors="JuniorCorzo"
 
-# Set working directory
 RUN apk add --no-cache bash
 WORKDIR /app
 
-# Copy only Gradle wrapper and config to cache dependencies
 COPY build.gradle settings.gradle gradlew ./
 COPY gradle ./gradle
 COPY .env .env
 
-# Ensure wrapper is executable
 RUN chmod +x gradlew
 
 
 
-# Download dependencies
 RUN ./gradlew dependencies --no-daemon
 
-# Copy source code
 COPY src ./src
 
-# Build the application (skip tests if preferred)
 RUN sh ./gradlew bootJar --no-daemon -x test
 
 
-# 2. Runtime stage
 FROM eclipse-temurin:21-jre-alpine
 
-# Create non-root user for security
 RUN addgroup -S spring && adduser -S spring -G spring
 USER spring:spring
 
-# Create app directory
 WORKDIR /app
 
-# Copy the executable jar from builder
 COPY --from=builder /app/build/libs/*.jar app.jar
 
-# Expose default Spring Boot port
 EXPOSE 8080
 
-# Optional healthcheck against Spring Boot actuator
-HEALTHCHECK --interval=30s --timeout=5s \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1
 
-# Start the application
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/Docker/production/.env.example
+++ b/Docker/production/.env.example
@@ -1,0 +1,19 @@
+#Databases config
+MONGO_URI=your_connection_to_mongo_db
+REDIS_HOST=your_url_connection_to_redis
+REDIS_PORT=your_port_for_redis
+SECRET_KEY=secret_key_for_signed_jwt
+
+# Cloudflare R2
+CLOUDFLARE_KEY_ACCESS=your_key_access_for_r2
+CLOUDFLARE_KEY_SECRET=your_secret_key_for_r2
+CLOUDFLARE_ENDPOINT=your_url_for_r2
+CLOUDFLARE_BUCKET_NAME=your_bucket_name
+CLOUDFLARE_PUBLIC_URL=your_public_url
+
+# Frontend
+PUBLIC_API_URL=your_api_url
+PUBLIC_CLOUDFLARE_URL=your_public_cloudflare_url
+
+# Api Config
+VERSION=0.0.1-SNAPSHOT

--- a/Docker/production/docker-deploy.yml
+++ b/Docker/production/docker-deploy.yml
@@ -1,0 +1,96 @@
+services:
+  mongo:
+    image: mongo:8.0.0
+    ports:
+      - "27017:27017"
+    command: ["--replSet", "rs0", "--bind_ip_all", "--port", "27017"]
+    healthcheck:
+      test: echo "try { rs.status() } catch (err) { rs.initiate({_id:'rs0',members:[{_id:0,host:'mongo:27017'}]}) }" | mongosh --port 27017 --quiet
+      interval: 5s
+      timeout: 30s
+      start_period: 0s
+      start_interval: 1s
+      retries: 30
+    volumes:
+      - mongo_data:/data/db
+      - mongo_config:/data/configdb
+    networks:
+      - mongo_net
+    deploy:
+      replicas: 1
+      resources:
+        reservations:
+          cpus: "0.5"
+        limits:
+          cpus: "1"
+          memory: 1GiB
+
+  redis:
+    image: redis:8.0-alpine
+    expose:
+      - "6379:6379"
+    command: ["redis-server", "redis.conf"]
+    volumes:
+      - redis_data:/data
+      - ./redis.conf:/data/redis.conf:Z
+    networks:
+      - redis_net
+    deploy:
+      replicas: 1
+      resources:
+        reservations:
+          cpus: "0.2"
+          memory: 256M
+        limits:
+          cpus: "0.5"
+          memory: 512M
+
+  api:
+    image: juniorcorzo:urban_style_backend
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mongo
+      - redis
+    env_file:
+      - .env
+    networks:
+      - api_net
+      - mongo_net
+      - redis_net
+    deploy:
+      replicas: 1
+      resources:
+        reservations:
+          cpus: "0.5"
+          memory: 256M
+        limits:
+          cpus: "1"
+          memory: 1GiB
+
+  frontend:
+    image: juniorcorzo:urban_style_frontend
+    depends_on:
+      - api
+    ports:
+      - 4321:4321
+    networks:
+      - api_net
+    deploy:
+      resources:
+        reservations:
+          cpus: "0.1"
+          memory: 128M
+        limits:
+          cpus: "0.3"
+          memory: 256M
+
+networks:
+  mongo_net:
+  redis_net:
+  api_net:
+
+volumes:
+  mongo_data:
+  mongo_config:
+  redis_data:

--- a/Docker/production/redis.conf
+++ b/Docker/production/redis.conf
@@ -1,0 +1,18 @@
+#host config
+bind 0.0.0.0
+
+# ───── Persistencia RDB ─────
+save 900 1
+save 300 10
+save 60 10000
+
+# Ruta y nombre del dump
+dir /data
+dbfilename dump.rdb
+
+# ───── Persistencia AOF ─────
+appendonly yes
+appendfilename appendonly.aof
+appendfsync everysec
+auto-aof-rewrite-percentage 100
+auto-aof-rewrite-min-size 64mb

--- a/Frontend/urban-style/.dockerignore
+++ b/Frontend/urban-style/.dockerignore
@@ -1,0 +1,5 @@
+.astro
+dist
+node_modules
+.vscode
+.env

--- a/Frontend/urban-style/Dockerfile
+++ b/Frontend/urban-style/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:22.17.1-alpine3.22 AS base
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml ./
+
+FROM base AS prod-deps
+
+RUN npm install -g pnpm
+RUN pnpm install --frozen-lockfile --prod
+
+FROM base AS build-deps
+
+RUN npm install -g pnpm
+RUN pnpm install --frozen-lockfile
+
+FROM build-deps AS build
+
+COPY .env.development .env
+COPY . .
+
+RUN pnpm run build
+
+FROM base AS runtime
+COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+
+ENV HOST=0.0.0.0
+ENV PORT=4321
+EXPOSE 4321
+ENTRYPOINT ["node", "./dist/server/entry.mjs"]


### PR DESCRIPTION
…, and services

- Added multi-stage Dockerfile for Spring Boot backend:
  * Uses Gradle builder stage for building JAR
  * Uses Eclipse Temurin JRE for runtime
  * Removed unused healthcheck and comments for cleaner image

- Added Dockerfile for Astro + React frontend:
  * Multi-stage build with pnpm
  * Includes build stage and lightweight runtime stage

- Added .dockerignore for frontend to exclude build artifacts and dev files

- Added production Docker Compose file (docker-deploy.yml):
  * Includes services: MongoDB, Redis, API (Spring Boot), and Frontend
  * Configured networks, volumes, and resource reservations/limits for Swarm
  * MongoDB configured with replica set and healthcheck for initialization
  *  with persistence (RDB + AOF) and mounted redis.conf
  * API and Frontend connected to dedicated networks for isolation
  * Exposed ports for API (8080) and Frontend (4321) Redis configured
- Added redis.conf with persistence and basic security settings

- Added .env.example for production environment variables:
  * MongoDB, Redis, Cloudflare R2, Frontend, API config placeholders

This commit sets up a complete production-ready Docker environment supporting: ✔ Spring Boot backend
✔ Astro + React frontend
✔ MongoDB with replica set
✔ Redis with persistence
✔ Resource management for Swarm deployments