### PR TITLE
feat(profile): Refactor Security Page and Add Account Deletion

### DIFF
--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/address/domain/repository/AddressRepository.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/address/domain/repository/AddressRepository.java
@@ -1,13 +1,35 @@
 package io.github.juniorcorzo.UrbanStyle.address.domain.repository;
 
 import io.github.juniorcorzo.UrbanStyle.address.domain.entities.AddressEntity;
+import org.springframework.data.mongodb.repository.DeleteQuery;
 import org.springframework.data.mongodb.repository.Query;
+import org.springframework.data.mongodb.repository.Update;
 import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Repository interface for managing {@link AddressEntity} data in MongoDB.
+ */
 public interface AddressRepository extends ListCrudRepository<AddressEntity, String> {
+    /**
+     * Finds all addresses associated with a specific user ID.
+     *
+     * @param userId The ID of the user.
+     * @return An {@link Optional} containing a list of {@link AddressEntity}.
+     */
     @Query("{ 'userId': ?0 }")
     Optional<List<AddressEntity>> findByUserId(String userId);
+
+    /**
+     * Deletes all addresses associated with a specific user ID.
+     * This operation is transactional.
+     *
+     * @param userId The ID of the user whose addresses should be deleted.
+     */
+    @Transactional
+    @DeleteQuery("{ 'userId': ?0 }")
+    void deleteByUserId(String userId);
 }

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/auth/application/service/CustomerUserDetailsService.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/auth/application/service/CustomerUserDetailsService.java
@@ -15,8 +15,9 @@ public class CustomerUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        UserEntity user = userRepository.findUserByEmail(email);
+    public UserDetails loadUserByUsername(String email) {
+        UserEntity user = userRepository.findUserByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
 
         return User
                 .withUsername(email)

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/auth/infrastructure/controller/AuthController.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/auth/infrastructure/controller/AuthController.java
@@ -1,6 +1,7 @@
 package io.github.juniorcorzo.UrbanStyle.auth.infrastructure.controller;
 
 import io.github.juniorcorzo.UrbanStyle.auth.application.service.AuthService;
+import io.github.juniorcorzo.UrbanStyle.common.application.utils.CookiesUtils;
 import io.github.juniorcorzo.UrbanStyle.user.infrastructure.adapter.dto.common.UserDTO;
 import io.github.juniorcorzo.UrbanStyle.auth.infrastructure.adapter.dto.request.UserCredentials;
 import io.github.juniorcorzo.UrbanStyle.auth.infrastructure.adapter.dto.response.AuthResponse;
@@ -27,13 +28,7 @@ public class AuthController {
     @PostMapping("/login")
     public AuthResponse login(@Valid @RequestBody UserCredentials credentials, HttpServletResponse response) {
         String accessToken = authService.login(credentials);
-        ResponseCookie cookie = ResponseCookie.from("accessToken", accessToken)
-                .httpOnly(true)
-                .maxAge(Duration.ofDays(30))
-                .path("/")
-                .build();
-
-        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        CookiesUtils.createCookie(response, "accessToken", accessToken, 30);
 
         return new AuthResponse(accessToken);
     }
@@ -47,15 +42,7 @@ public class AuthController {
     @DeleteMapping("/sign-out")
     @PreAuthorize("hasRole('USER')")
     public ResponseDTO<Object> signOut(HttpServletResponse response){
-        response.addHeader(
-                HttpHeaders.SET_COOKIE,
-                ResponseCookie.from("accessToken", "chaooooo-no-vuelvas-a-volver")
-                        .httpOnly(true)
-                        .maxAge(0)
-                        .path("/")
-                        .build()
-                        .toString()
-        );
+        CookiesUtils.clearCookie(response, "accessToken");
 
         return new ResponseDTO<>(
                 HttpStatus.OK,

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/auth/infrastructure/exceptions/CustomAuthenticationEntrypoint.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/auth/infrastructure/exceptions/CustomAuthenticationEntrypoint.java
@@ -11,6 +11,7 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 
 @Component
 @RequiredArgsConstructor
@@ -22,10 +23,14 @@ public class CustomAuthenticationEntrypoint implements AuthenticationEntryPoint 
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json");
 
-        this.objectMapper.writeValue(response.getOutputStream(), ResponseError.builder()
+        final ResponseError responseError = ResponseError.builder()
                 .status(HttpStatus.UNAUTHORIZED)
                 .error(authException.getMessage())
-                .build()
-        );
+                .build();
+
+        final String jsonResponse = this.objectMapper.writeValueAsString(responseError);
+        PrintWriter printStream = response.getWriter();
+        printStream.write(jsonResponse);
+        printStream.flush();
     }
 }

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/common/application/utils/CookiesUtils.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/common/application/utils/CookiesUtils.java
@@ -1,0 +1,57 @@
+package io.github.juniorcorzo.UrbanStyle.common.application.utils;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
+import java.time.Duration;
+
+/**
+ * Utility class for creating and clearing HTTP cookies.
+ * This class provides static methods to handle cookie operations in a centralized manner.
+ */
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public class CookiesUtils {
+
+    /**
+     * Creates an HTTP-only cookie and adds it to the HttpServletResponse.
+     *
+     * @param response The HttpServletResponse to which the cookie will be added.
+     * @param cookieName The name of the cookie.
+     * @param cookieValue The value of the cookie.
+     * @param maxAgeInDays The maximum age of the cookie in days.
+     * @return The modified HttpServletResponse with the new cookie header.
+     */
+    public static HttpServletResponse createCookie(HttpServletResponse response, String cookieName, String cookieValue, long maxAgeInDays) {
+        ResponseCookie cookie = ResponseCookie.from(cookieName, cookieValue)
+                .httpOnly(true)
+                .maxAge(Duration.ofDays(maxAgeInDays))
+                .path("/")
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        return response;
+    }
+
+    /**
+     * Clears a specified cookie by setting its max age to 0.
+     *
+     * @param response The HttpServletResponse to which the clearing cookie header will be added.
+     * @param cookieName The name of the cookie to clear.
+     * @return The modified HttpServletResponse with the cookie clearing header.
+     */
+    public static HttpServletResponse clearCookie(HttpServletResponse response, String cookieName) {
+        response.addHeader(
+                HttpHeaders.SET_COOKIE,
+                ResponseCookie.from(cookieName, "")
+                        .httpOnly(true)
+                        .maxAge(0)
+                        .path("/")
+                        .build()
+                        .toString()
+        );
+        return response;
+    }
+
+}

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/common/infrastructure/controller/HandlerController.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/common/infrastructure/controller/HandlerController.java
@@ -11,6 +11,7 @@ import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -153,6 +154,13 @@ public class HandlerController {
 
     @ExceptionHandler(NotFoundTermsValid.class)
     public ResponseEntity<ResponseError> handleNotFoundTermsValid(NotFoundTermsValid e) {
+        return new ResponseEntity<>(new ResponseError(
+                HttpStatus.NOT_FOUND,
+                e.getMessage()
+        ), HttpStatus.NOT_FOUND);
+    }
+    @ExceptionHandler(UsernameNotFoundException.class)
+    public ResponseEntity<ResponseError> handleUsernameNotFound(UsernameNotFoundException e) {
         return new ResponseEntity<>(new ResponseError(
                 HttpStatus.NOT_FOUND,
                 e.getMessage()

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/user/application/service/UserDeletingService.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/user/application/service/UserDeletingService.java
@@ -21,9 +21,11 @@ public class UserDeletingService {
     /**
      * Performs a comprehensive deletion of a user's account and associated data.
      * This process includes:
-     * 1. Soft-deleting the user record by unsetting personal information.
-     * 2. Deleting all associated addresses.
-     * 3. Deleting the user's avatar from storage.
+     * <ol>
+     * <li>Deleting the user's avatar from storage.</li>
+     * <li>Soft-deleting the user record by unsetting personal information.</li>
+     * <li>Deleting all associated addresses.</li>
+     * <ol/>
      * The entire operation is transactional.
      *
      * @param userId The ID of the user to be deleted.
@@ -32,9 +34,9 @@ public class UserDeletingService {
      */
     @Transactional
     public ResponseDTO<Object> deleteUser(String userId, String reason) {
+        this.userAvatarService.deleteAvatar(userId);
         this.userRepository.deleteById(userId, reason);
         this.addressRepository.deleteByUserId(userId);
-        this.userAvatarService.deleteAvatar(userId);
 
         return new ResponseDTO<>(
                 HttpStatus.OK,

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/user/application/service/UserDeletingService.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/user/application/service/UserDeletingService.java
@@ -1,0 +1,4 @@
+package io.github.juniorcorzo.UrbanStyle.user.application.service;
+
+public class UserDeletingService {
+}

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/user/application/service/UserDeletingService.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/user/application/service/UserDeletingService.java
@@ -1,4 +1,44 @@
 package io.github.juniorcorzo.UrbanStyle.user.application.service;
 
+import io.github.juniorcorzo.UrbanStyle.address.domain.repository.AddressRepository;
+import io.github.juniorcorzo.UrbanStyle.common.infrastructure.adapter.dtos.response.ResponseDTO;
+import io.github.juniorcorzo.UrbanStyle.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Service responsible for handling the deletion of user accounts.
+ */
+@Service
+@RequiredArgsConstructor
 public class UserDeletingService {
+    private final UserRepository userRepository;
+    private final AddressRepository addressRepository;
+    private final UserAvatarService userAvatarService;
+
+    /**
+     * Performs a comprehensive deletion of a user's account and associated data.
+     * This process includes:
+     * 1. Soft-deleting the user record by unsetting personal information.
+     * 2. Deleting all associated addresses.
+     * 3. Deleting the user's avatar from storage.
+     * The entire operation is transactional.
+     *
+     * @param userId The ID of the user to be deleted.
+     * @param reason The reason for the deletion.
+     * @return A {@link ResponseDTO} indicating the result of the operation.
+     */
+    @Transactional
+    public ResponseDTO<Object> deleteUser(String userId, String reason) {
+        this.userRepository.deleteById(userId, reason);
+        this.addressRepository.deleteByUserId(userId);
+        this.userAvatarService.deleteAvatar(userId);
+
+        return new ResponseDTO<>(
+                HttpStatus.OK,
+                "User deleted successfully"
+        );
+    }
 }

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/user/application/service/UserService.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/user/application/service/UserService.java
@@ -122,21 +122,6 @@ public class UserService {
         return new ResponseDTO<>(HttpStatus.OK, this.getUserById(id).data(), "User role updated");
     }
 
-    public ResponseDTO<UserDTO> deleteUser(String id) {
-        try {
-            UserEntity userEntity = this.userRepository.findById(id)
-                    .orElseThrow(() -> new DocumentNotFound(DocumentsName.USER, id));
-
-            this.userAvatarService.deleteAvatar(id);
-            this.userRepository.delete(userEntity);
-
-            return new ResponseDTO<>(HttpStatus.OK, List.of(userMapper.toDto(userEntity)), "User deleted");
-        } catch (Exception e) {
-            log.error("Error deleting user: {}", e.getMessage(), e);
-            throw new DeleteDocumentFailed(DocumentsName.USER, id);
-        }
-    }
-
     private void changeStatus(String id, Roles role) {
         this.userRepository.changeRole(id, role);
     }

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/user/application/service/UserService.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/user/application/service/UserService.java
@@ -2,7 +2,6 @@ package io.github.juniorcorzo.UrbanStyle.user.application.service;
 
 import io.github.juniorcorzo.UrbanStyle.common.domain.enums.DocumentsName;
 import io.github.juniorcorzo.UrbanStyle.common.domain.enums.Roles;
-import io.github.juniorcorzo.UrbanStyle.common.domain.exceptions.DeleteDocumentFailed;
 import io.github.juniorcorzo.UrbanStyle.common.domain.exceptions.DocumentNotFound;
 import io.github.juniorcorzo.UrbanStyle.common.domain.exceptions.FieldExists;
 import io.github.juniorcorzo.UrbanStyle.common.domain.exceptions.SaveDocumentFailed;
@@ -30,11 +29,6 @@ public class UserService {
     private final UserAvatarService userAvatarService;
     private final UserPasswordService userPasswordService;
     private final DataConsentService dataConsentService;
-
-    public ResponseDTO<UserDTO> getUserByCredentials(String email) {
-        UserEntity userResponse = this.userRepository.findUserByEmail(email);
-        return new ResponseDTO<>(HttpStatus.OK, List.of(userMapper.toDto(userResponse)), "User found");
-    }
 
     public ResponseDTO<UserDTO> getUserById(String id) {
         UserEntity userResponse = this.userRepository.findById(id)

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/user/domain/entities/UserEntity.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/user/domain/entities/UserEntity.java
@@ -4,6 +4,8 @@ import io.github.juniorcorzo.UrbanStyle.common.domain.enums.Roles;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.MongoId;
@@ -11,24 +13,78 @@ import org.springframework.security.core.GrantedAuthority;
 
 import java.time.LocalDateTime;
 
+/**
+ * Represents a user in the system.
+ * This entity stores user information, including credentials, profile data, and auditing fields.
+ */
 @Document("users")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserEntity implements GrantedAuthority {
+    /**
+     * The unique identifier for the user.
+     */
     @MongoId
     private String id;
+    /**
+     * The full name of the user.
+     */
     private String name;
+    /**
+     * The user's email address. It is indexed and must be unique.
+     */
     @Indexed(unique = true)
     private String email;
+    /**
+     * The user's encrypted password.
+     */
     private String password;
+    /**
+     * The filename or identifier for the user's avatar image.
+     * Defaults to "default_profile.webp".
+     */
     private String avatar = "default_profile.webp";
+    /**
+     * Stores data consent information provided by the user.
+     */
     private DataConsent dataConsent;
+    /**
+     * The role of the user in the system (e.g., USER, ADMIN).
+     */
     private Roles role;
+    /**
+     * The user's phone number.
+     */
     private String phone;
-    private LocalDateTime createdAt = LocalDateTime.now();
-    private LocalDateTime updatedAt = LocalDateTime.now();
+    /**
+     * Flag to indicate if the user account is soft-deleted.
+     * Defaults to false.
+     */
+    private boolean isDeleted = false;
+    /**
+     * The reason provided for the user's deletion.
+     */
+    private String deletedReason;
+    /**
+     * The timestamp when the user was created.
+     */
+    @CreatedDate
+    private LocalDateTime createdAt;
+    /**
+     * The timestamp when the user was last updated.
+     */
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+    /**
+     * The timestamp when the user was soft-deleted.
+     */
+    private LocalDateTime deletedAt;
 
+    /**
+     * Returns the user's role as a string for Spring Security.
+     * @return The name of the user's role.
+     */
     @Override
     public String getAuthority() {
         return this.role.name();

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/user/domain/repository/UserRepository.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/user/domain/repository/UserRepository.java
@@ -1,9 +1,9 @@
 package io.github.juniorcorzo.UrbanStyle.user.domain.repository;
 
-import io.github.juniorcorzo.UrbanStyle.user.domain.entities.DataConsent;
-import io.github.juniorcorzo.UrbanStyle.user.domain.entities.UserEntity;
 import io.github.juniorcorzo.UrbanStyle.common.domain.enums.Roles;
 import io.github.juniorcorzo.UrbanStyle.product.domain.adapter.proyections.ObtainPassword;
+import io.github.juniorcorzo.UrbanStyle.user.domain.entities.DataConsent;
+import io.github.juniorcorzo.UrbanStyle.user.domain.entities.UserEntity;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.Update;
@@ -11,33 +11,95 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+/**
+ * Repository interface for managing {@link UserEntity} data in MongoDB.
+ */
 @Repository
-
 public interface UserRepository extends MongoRepository<UserEntity, String> {
+    /**
+     * Finds a user by their email address.
+     * @param email The email to search for.
+     * @return The {@link UserEntity} found.
+     */
     @Query("{ 'email': ?0 }")
     UserEntity findUserByEmail(String email);
 
+    /**
+     * Finds the password for a given user ID.
+     * @param userId The ID of the user.
+     * @return An {@link Optional} containing the user's password projection.
+     */
     @Query("{ '_id': ?0 }")
     Optional<ObtainPassword> findPasswordById(String userId);
 
+    /**
+     * Changes the role of a user.
+     * @param userId The ID of the user to update.
+     * @param role The new role to assign.
+     */
     @Query("{ '_id': ?0 }")
     @Update("{ '$set': { 'role': ?1} }")
     void changeRole(String userId, Roles role);
 
 
+    /**
+     * Updates user profile information.
+     * @param user The {@link UserEntity} with updated information.
+     */
     @Query("{'_id': ?#{[0].id} }")
-    @Update(value = "{ '$set': { 'name': ?#{[0].name}, 'email': ?#{[0].email}, 'phone': ?#{[0].phone}, 'updatedAt': ?#{[0].updatedAt} } }" )
+    @Update(value = "{ '$set': { 'name': ?#{[0].name}, 'email': ?#{[0].email}, 'phone': ?#{[0].phone}, 'updatedAt': ?#{[0].updatedAt} } }")
     void updateUser(UserEntity user);
 
+    /**
+     * Updates the data consent information for a user.
+     * @param userId The ID of the user to update.
+     * @param dataConsent The new data consent information.
+     */
     @Query("{ '_id': ?0 }")
     @Update("{ '$set': { 'dataConsent': ?1} }")
     void updateUserConsent(String userId, DataConsent dataConsent);
 
+    /**
+     * Inserts a new avatar for a user.
+     * @param userId The ID of the user to update.
+     * @param avatar The new avatar identifier.
+     */
     @Query("{ '_id': ?0 }")
     @Update("{ '$set': { 'avatar': ?1 } }")
-    void insertNewAvatar(String userId,String avatar);
+    void insertNewAvatar(String userId, String avatar);
 
+    /**
+     * Changes the password for a user.
+     * @param userId The ID of the user to update.
+     * @param newPassword The new encrypted password.
+     */
     @Query("{ '_id': ?0 }")
     @Update("{ '$set': { 'password': ?1 } }")
     void changePassword(String userId, String newPassword);
+
+    /**
+     * Performs a soft delete on a user account.
+     * This method sets the `isDeleted` flag to true, records the deletion reason and timestamp,
+     * and unsets sensitive personal information.
+     *
+     * @param userId The ID of the user to delete.
+     * @param reason The reason for the deletion.
+     */
+    @Query("{ '_id': ?0 }")
+    @Update("""
+            {
+                '$set': {
+                    'isDeleted': true,
+                    'deletedReason': ?1,
+                    'deletedAt': ?#{T(java.time.LocalDateTime).now()},
+                },
+                '$unset': {
+                        'email': null,
+                        'phone': null,
+                        'avatar': null,
+                        'password': null,
+                },
+            }
+            """)
+    void deleteById(String userId, String reason);
 }

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/user/domain/repository/UserRepository.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/user/domain/repository/UserRepository.java
@@ -22,7 +22,7 @@ public interface UserRepository extends MongoRepository<UserEntity, String> {
      * @return The {@link UserEntity} found.
      */
     @Query("{ 'email': ?0 }")
-    UserEntity findUserByEmail(String email);
+    Optional<UserEntity> findUserByEmail(String email);
 
     /**
      * Finds the password for a given user ID.

--- a/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/user/infrastructure/controller/UserController.java
+++ b/Backend/UrbanStyle/src/main/java/io/github/juniorcorzo/UrbanStyle/user/infrastructure/controller/UserController.java
@@ -98,6 +98,14 @@ public class UserController {
         return userDTO;
     }
 
+    /**
+     * Deletes a user account and clears the authentication cookie.
+     *
+     * @param id The ID of the user to be deleted.
+     * @param reason The reason for the deletion.
+     * @param response The HttpServletResponse to clear the cookie.
+     * @return A {@link ResponseDTO} indicating the result of the operation.
+     */
     @DeleteMapping("/delete")
     @PreAuthorize("hasRole('USER')")
     public ResponseDTO<Object> deleteUser(

--- a/Frontend/urban-style/eslint.config.js
+++ b/Frontend/urban-style/eslint.config.js
@@ -1,12 +1,25 @@
 import eslintPluginAstro from 'eslint-plugin-astro'
 import { defineConfig, globalIgnores } from 'eslint/config'
+import tsParser from '@typescript-eslint/parser'
 
 export default defineConfig([
 	...eslintPluginAstro.configs.recommended,
 	{
+		files: ['**/*.ts', '**/*.tsx'],
+		languageOptions: {
+			parser: tsParser,
+			parserOptions: {
+				ecmaFeatures: {
+					jsx: true,
+				},
+			},
+		},
+	},
+	{
+		files: ['**/*.js', '**/*.mjs', '**/*.ts', '**/*.tsx', '**/*.astro'],
 		rules: {
 			'comma-dangle': ['error', 'always-multiline'],
 		},
 	},
-	globalIgnores(['.dist/']),
+	globalIgnores(['dist/']),
 ])

--- a/Frontend/urban-style/src/components/dashboard/react/components/modals/ModalHeader.tsx
+++ b/Frontend/urban-style/src/components/dashboard/react/components/modals/ModalHeader.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 export default function ModalHeader({ handleModal, title }: Props) {
 	return (
-		<div className="bg-accent border-border sticky top-0 z-50 flex w-full items-center justify-between border-b px-4 py-2.5 text-center">
+		<div className="bg-accent border-border sticky top-0 z-50 flex w-full items-center justify-between rounded-t-md border-b px-4 py-2.5 text-center">
 			<h2 className="text-text text-2xl font-bold">{title}</h2>
 			<button
 				onClick={handleModal}

--- a/Frontend/urban-style/src/components/profile/react/components/ActionsFooter.tsx
+++ b/Frontend/urban-style/src/components/profile/react/components/ActionsFooter.tsx
@@ -10,12 +10,7 @@ type ActionFooterProps = {
 
 export function ActionsFooter({ canSubmit, canReset, resetFn, sendFn }: ActionFooterProps) {
 	return (
-		<div
-			className={cn(
-				'bg-foreground/90 bottom-0 flex w-full gap-5 px-5 py-2 backdrop-blur-lg',
-				canReset ? 'justify-between' : 'justify-end',
-			)}
-		>
+		<div className={cn('bottom-0 flex w-full justify-end gap-5 py-2 backdrop-blur-lg')}>
 			<Button
 				className={cn(!canReset && 'hidden')}
 				size="sm"

--- a/Frontend/urban-style/src/components/profile/react/components/ChangePasswordForm.tsx
+++ b/Frontend/urban-style/src/components/profile/react/components/ChangePasswordForm.tsx
@@ -1,0 +1,49 @@
+import { Button } from '@/components/react/Button'
+import TextInput from '@/components/react/inputs/TextInput'
+import { cn } from '@/lib/cn'
+import { useChangePassword } from '../hooks/useChangePassword'
+import { ActionsFooter } from './ActionsFooter'
+import { HeaderSection } from './HeaderSection'
+
+/**
+ * Renders the change password form.
+ * This component provides a form for the user to change their password.
+ */
+export function ChangePasswordForm() {
+	const { handleInputChange, canSubmit, sendRequest } = useChangePassword()
+
+	return (
+		<>
+			<div className="flex h-full flex-col gap-2 px-5 md:px-11">
+				<HeaderSection
+					title="Cambiar contraseña"
+					description="Para mantener tu cuenta segura, te recomendamos cambiar tu contraseña periódicamente. Elige una contraseña fuerte que no uses en otros sitios."
+				/>
+				<div className="grid items-end gap-3 md:grid-cols-2">
+					<TextInput
+						name="oldPassword"
+						label="Contraseña actual"
+						placeholder="Ingresa tu contraseña actual"
+						type="password"
+						onChange={handleInputChange}
+					/>
+					<TextInput
+						name="newPassword"
+						label="Nueva contraseña"
+						placeholder="Mínimo 8 caracteres"
+						type="password"
+						onChange={handleInputChange}
+					/>
+					<TextInput
+						name="confirmPassword"
+						label="Confirmar nueva contraseña"
+						placeholder="Confirma tu nueva contraseña"
+						type="password"
+						onChange={handleInputChange}
+					/>
+				</div>
+				<ActionsFooter canSubmit={canSubmit} sendFn={sendRequest} />
+			</div>
+		</>
+	)
+}

--- a/Frontend/urban-style/src/components/profile/react/components/DeleteAccount.tsx
+++ b/Frontend/urban-style/src/components/profile/react/components/DeleteAccount.tsx
@@ -1,0 +1,30 @@
+import { Button } from '@/components/react/Button'
+import { HeaderSection } from './HeaderSection'
+import { DeleteAccountDialog, type DeleteAccountDialogRef } from './dialog/DeleteAccountDialog'
+import { useRef } from 'react'
+
+/**
+ * Renders the delete account section in the user profile.
+ * This component displays information about account deletion and a button to open the delete account dialog.
+ */
+export function DeleteAccount() {
+	const dialogRef = useRef<DeleteAccountDialogRef>(null)
+
+	return (
+		<div className="flex h-full w-full items-center justify-between gap-2 px-5 pb-5 md:px-11">
+			<HeaderSection
+				title="Eliminar cuenta"
+				description="Una vez que elimines tu cuenta, perderás acceso a todos tus datos, historial de pedidos y configuraciones. Esta acción es irreversible."
+			/>
+
+			<Button
+				className="bg-red border-red text-nowrap border-2 text-slate-100"
+				size="sm"
+				onClick={() => dialogRef.current?.showModal()}
+			>
+				Eliminar cuenta
+			</Button>
+			<DeleteAccountDialog ref={dialogRef} />
+		</div>
+	)
+}

--- a/Frontend/urban-style/src/components/profile/react/components/HeaderSection.tsx
+++ b/Frontend/urban-style/src/components/profile/react/components/HeaderSection.tsx
@@ -1,0 +1,13 @@
+type Props = {
+	title: string
+	description?: string
+}
+
+export function HeaderSection({ title, description }: Props) {
+	return (
+		<div className="flex h-full flex-col gap-1">
+			<span className="text-lg font-medium leading-relaxed tracking-wide">{title}</span>
+			{description && <p className="text-base text-gray-500">{description}</p>}
+		</div>
+	)
+}

--- a/Frontend/urban-style/src/components/profile/react/components/UserOptions.tsx
+++ b/Frontend/urban-style/src/components/profile/react/components/UserOptions.tsx
@@ -28,8 +28,8 @@ export function UserOptions() {
 
 	console.log(option)
 	return (
-		<article className="flex h-full w-full max-w-full grow flex-col gap-5">
-			<div className="px-5">
+		<article className="flex h-full w-full max-w-full grow flex-col gap-5 px-5">
+			<div>
 				<OptionsTab />
 			</div>
 			{optionsMap.get(option ?? 'PERSONAL_DATA')}

--- a/Frontend/urban-style/src/components/profile/react/components/UserSecurity.tsx
+++ b/Frontend/urban-style/src/components/profile/react/components/UserSecurity.tsx
@@ -1,57 +1,12 @@
-import { Button } from '@/components/react/Button'
-import TextInput from '@/components/react/inputs/TextInput'
-import { cn } from '@/lib/cn'
-import { useChangePassword } from '../hooks/useChangePassword'
-import { ActionsFooter } from './ActionsFooter'
+import { ChangePasswordForm } from './ChangePasswordForm'
+import { DeleteAccount } from './DeleteAccount'
 
 export function UserSecurity() {
-	const { isPassword, handleInputChange, handleValidatePassword, canSubmit, sendRequest } =
-		useChangePassword()
-
 	return (
 		<>
-			<div className="flex h-full flex-col gap-3 px-5 md:px-11">
-				<span className="text-lg font-medium tracking-wide">Cambiar contraseña</span>
-				<div className="grid items-end gap-3 md:grid-cols-2">
-					<span className="max-xs:flex-col xs:items-end col-span-full flex gap-x-5 gap-y-3">
-						<TextInput
-							name="oldPassword"
-							className={cn(
-								isPassword && 'border-green-1 focus:border-green-1 border-2 focus:ring-0',
-								isPassword === false && 'border-red focus:border-red border-2 focus:shadow-none',
-							)}
-							label="Contraseña actual"
-							placeholder="Ingresa tu contraseña actual"
-							type="password"
-							onChange={handleInputChange}
-						/>
-						<Button
-							className="h-full max-h-10 text-nowrap font-semibold"
-							size="sm"
-							onClick={handleValidatePassword}
-						>
-							Verificar Contraseña
-						</Button>
-					</span>
-					<TextInput
-						name="newPassword"
-						label="Nueva contraseña"
-						placeholder="Mínimo 8 caracteres"
-						type="password"
-						onChange={handleInputChange}
-						disabled={!isPassword}
-					/>
-					<TextInput
-						name="confirmPassword"
-						label="Confirmar nueva contraseña"
-						placeholder="Confirma tu nueva contraseña"
-						type="password"
-						onChange={handleInputChange}
-						disabled={!isPassword}
-					/>
-				</div>
-			</div>
-			<ActionsFooter canSubmit={canSubmit} sendFn={sendRequest} />
+			<ChangePasswordForm />
+			<hr className="border-border/70 border-t-2" />
+			<DeleteAccount />
 		</>
 	)
 }

--- a/Frontend/urban-style/src/components/profile/react/components/dialog/DeleteAccountDialog.tsx
+++ b/Frontend/urban-style/src/components/profile/react/components/dialog/DeleteAccountDialog.tsx
@@ -1,0 +1,78 @@
+import ModalHeader from '@/components/dashboard/react/components/modals/ModalHeader'
+import { Button } from '@/components/react/Button'
+import TextInput from '@/components/react/inputs/TextInput'
+import { useDeleteAccountDialog } from '../../hooks/useDeleteAccountDialog'
+
+export type DeleteAccountDialogRef = {
+	showModal: () => void
+	close: () => void
+}
+
+/**
+ * @property ref - A ref to the dialog component.
+ */
+type DeleteAccountDialogProps = {
+	ref: React.RefObject<DeleteAccountDialogRef | null>
+}
+
+/**
+ * Renders the delete account dialog.
+ * This component provides a confirmation dialog for account deletion, requiring the user to enter their password.
+ * @param {DeleteAccountDialogProps} props - The component props.
+ */
+export function DeleteAccountDialog({ ref }: DeleteAccountDialogProps) {
+	const { dialogRef, isPasswordValid, handleInputChange, handleDeleteAccount, handleClose } =
+		useDeleteAccountDialog(ref)
+
+	return (
+		<dialog
+			ref={dialogRef}
+			id="delete_account_dialog"
+			className="-translate-1/2 fixed inset-0 left-1/2 top-1/2 z-[999] w-full max-w-xl bg-transparent px-3"
+		>
+			<div className="bg-background border-border shadow-crust overflow-visible rounded-md border-2 shadow-md">
+				<ModalHeader title="¿Eliminar tu Cuenta?" handleModal={handleClose} />
+				<div className="bg-background flex flex-col gap-6 p-6">
+					<p className="prose">
+						Estás a punto de eliminar tu cuenta. Esta acción es irreversible y se borrarán los
+						siguientes datos asociados a ella:
+						<ul className="list-inside list-disc">
+							<li> Correo electrónico</li>
+							<li> Número de teléfono</li>
+							<li> Direcciones guardadas</li>
+							<li> Contraseña</li>
+						</ul>
+						Por motivos legales, tu nombre y el historial de órdenes realizadas se conservarán en
+						nuestros registros.
+					</p>
+					<div>
+						<TextInput
+							type="password"
+							name="password"
+							label="Para confirmar, escribe tu contraseña actual:"
+							placeholder="Contraseña actual"
+							onChange={handleInputChange}
+						/>
+					</div>
+					<div className="inline-flex gap-2 self-end">
+						<Button
+							className="border-0 bg-transparent hover:border"
+							onClick={handleClose}
+							size="sm"
+						>
+							Cancelar
+						</Button>
+						<Button
+							className="bg-red border-red shadow-red-2 text-slate-100"
+							onClick={handleDeleteAccount}
+							disabled={!isPasswordValid}
+							size="sm"
+						>
+							Eliminar Cuenta
+						</Button>
+					</div>
+				</div>
+			</div>
+		</dialog>
+	)
+}

--- a/Frontend/urban-style/src/components/profile/react/hooks/useChangePassword.ts
+++ b/Frontend/urban-style/src/components/profile/react/hooks/useChangePassword.ts
@@ -1,10 +1,9 @@
 import { showErrorOnlyField } from '@/lib/showErrorMessages'
 import { debounce } from '@/lib/utils/debounce'
-import { changePasswordScheme, type ChangePasswordValid } from '@/lib/validations/user.validations'
+import { changePasswordScheme } from '@/lib/validations/user.validations'
 import { UserService } from '@/service/user.service'
 import { userStore } from '@/state/user.state'
 import { useStore } from '@nanostores/react'
-import { useState, useCallback, type ChangeEvent, useRef } from 'react'
 import { useFormHandler } from '@/components/react/hooks/useFormHandler'
 import ToasterManager from '@/lib/utils/ToasterManager'
 import { ResponseException } from '@/exceptions/response.exception'
@@ -15,14 +14,19 @@ type ChangePassword = {
 	confirmPassword: string
 }
 
+/**
+ * Custom hook to manage the change password form.
+ * @returns An object with event handlers and form state.
+ */
 export const useChangePassword = () => {
 	const user = useStore(userStore)
-	const [isPassword, setPassword] = useState<boolean>()
 	const {
 		formState: passwordValues,
 		handleInputChange,
 		canSubmit,
-	} = useFormHandler<ChangePassword>()
+	} = useFormHandler<ChangePassword>({
+		validate: changePasswordScheme,
+	})
 
 	const handleChangePassword = (userId: string, oldPassword: string, newPassword: string) =>
 		UserService.changePassword(userId, oldPassword, newPassword).then((response) => {
@@ -57,12 +61,10 @@ export const useChangePassword = () => {
 
 				throw new ResponseException(response.error)
 			}
-			setPassword(response.data)
 		})
 	}
 
 	return {
-		isPassword,
 		handleInputChange,
 		handleValidatePassword,
 		canSubmit,

--- a/Frontend/urban-style/src/components/profile/react/hooks/useDeleteAccountDialog.ts
+++ b/Frontend/urban-style/src/components/profile/react/hooks/useDeleteAccountDialog.ts
@@ -1,0 +1,82 @@
+import { ResponseException } from '@/exceptions/response.exception'
+import { $ } from '@/lib/dom-selector'
+import { toggleErrorMessage } from '@/lib/showErrorMessages'
+import { debounce } from '@/lib/utils/debounce'
+import ToasterManager from '@/lib/utils/ToasterManager'
+import { UserService } from '@/service/user.service'
+import { userStore } from '@/state/user.state'
+import { useStore } from '@nanostores/react'
+import { navigate } from 'astro:transitions/client'
+import { useImperativeHandle, useMemo, useRef, useState, type ChangeEvent } from 'react'
+import type { DeleteAccountDialogRef } from '../components/dialog/DeleteAccountDialog'
+
+/**
+ * Custom hook to manage the delete account dialog.
+ * @param ref - A ref to the dialog component.
+ * @returns An object with the dialog ref, password validation status, and event handlers.
+ */
+export function useDeleteAccountDialog(ref: React.RefObject<DeleteAccountDialogRef | null>) {
+	const dialogRef = useRef<HTMLDialogElement>(null)
+	const user = useStore(userStore)
+	const [isPasswordValid, setPasswordValid] = useState(false)
+
+	const userId = useMemo(() => user?.id, [user])
+
+	useImperativeHandle(ref, () => {
+		if (!dialogRef.current) throw new Error('Dialog ref is not assigned')
+
+		return {
+			showModal: () => dialogRef.current?.showModal(),
+			close: () => dialogRef.current?.close(),
+		}
+	})
+
+	const verifyPassword = debounce(async (value: string) => {
+		if (!userId) return
+
+		const result = await UserService.validatePassword(userId, value)
+		if (!result.success) {
+			toggleErrorMessage('Lo sentimos, ocurrio un error', $('#password_error') as HTMLSpanElement)
+			throw new ResponseException(result.error)
+		}
+
+		if (!result.data)
+			toggleErrorMessage('Contraseña incorrecta', $('#password_error') as HTMLSpanElement)
+
+		setPasswordValid(result.data)
+	}, 300)
+
+	const handleInputChange = async (event: ChangeEvent<HTMLInputElement>) => {
+		const value = event.target.value
+		if (value.length === 0) return
+
+		await verifyPassword(value)
+	}
+
+	const sendRequest = async () => {
+		if (!userId) return
+		const result = await UserService.deleteUser(userId, 'For request of user')
+		if (!result.success) throw new ResponseException(result.error)
+		navigate('/home')
+	}
+
+	const handleDeleteAccount = () => {
+		ToasterManager.emitPromise({
+			promise: sendRequest(),
+			config: {
+				success: 'Usuario eliminado con exito',
+				error: 'Ha ocurrido un error, intente mas tarde',
+			},
+		})
+	}
+
+	const handleClose = () => dialogRef.current?.close()
+
+	return {
+		dialogRef,
+		isPasswordValid,
+		handleInputChange,
+		handleDeleteAccount,
+		handleClose,
+	}
+}

--- a/Frontend/urban-style/src/components/react/Button.tsx
+++ b/Frontend/urban-style/src/components/react/Button.tsx
@@ -16,7 +16,7 @@ export function Button({ id, size = 'md', children, className, ...props }: Props
 			id={id}
 			className={cn(
 				sizeClasses[size],
-				'bg-accent-2/70 backdrop-blur-xs backdrop-brightness-80 text-text border-border shadow-accent-2 cursor-pointer rounded border text-lg font-semibold hover:shadow disabled:cursor-not-allowed disabled:opacity-90',
+				'bg-accent-2 text-text border-border shadow-accent-2 not-disabled:hover:scale-105 not-disabled:hover:shadow cursor-pointer rounded border text-lg font-semibold transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-90',
 				className,
 			)}
 			{...props}

--- a/Frontend/urban-style/src/components/react/hooks/useDragging.ts
+++ b/Frontend/urban-style/src/components/react/hooks/useDragging.ts
@@ -30,6 +30,6 @@ export function useDragging() {
 		isDragging,
 		handleDrag: handleDragEnter,
 		handleDragLeave,
-		handleDrop
+		handleDrop,
 	}
 }

--- a/Frontend/urban-style/src/components/react/hooks/useFormHandler.ts
+++ b/Frontend/urban-style/src/components/react/hooks/useFormHandler.ts
@@ -1,11 +1,15 @@
 import type { SelectOptions } from '@/interface/form-mediator.interface'
 import { showErrorOnlyField } from '@/lib/showErrorMessages'
-import { useEffect, useRef, useState, type ChangeEvent } from 'react'
-import type { ZodObject, ZodRawShape } from 'zod'
+import { useEffect, useState, type ChangeEvent } from 'react'
+import type { ZodEffects, ZodObject, ZodRawShape } from 'zod'
 
+/**
+ * @property {T} [initializerData] - Initial data for the form.
+ * @property {ZodObject<ZodRawShape> | ZodEffects<ZodObject<ZodRawShape>>} [validate] - A Zod schema or a Zod schema with effects to validate the form.
+ */
 type useFormHandlerProps<T> = {
 	initializerData?: T
-	validate?: ZodObject<ZodRawShape>
+	validate?: ZodObject<ZodRawShape> | ZodEffects<ZodObject<ZodRawShape>>
 }
 
 export const useFormHandler = <T>(initial?: useFormHandlerProps<T>) => {

--- a/Frontend/urban-style/src/components/react/inputs/LabelInput.tsx
+++ b/Frontend/urban-style/src/components/react/inputs/LabelInput.tsx
@@ -7,7 +7,7 @@ interface Props extends PropsWithChildren {
 export function LabelInput({ label, children }: Props) {
 	return (
 		// biome-ignore lint/a11y/noLabelWithoutControl: <explanation>
-		<label className="flex w-full flex-col gap-1">
+		<label className="text-text flex w-full flex-col gap-1">
 			<span>{`${label}`}</span>
 			{children}
 		</label>

--- a/Frontend/urban-style/src/layouts/LayoutWithSidebar.astro
+++ b/Frontend/urban-style/src/layouts/LayoutWithSidebar.astro
@@ -19,6 +19,7 @@ const { title = 'Urban Style' } = Astro.props
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<title>{title}</title>
+		<script is:inline src="https://unpkg.com/react-scan/dist/auto.global.js"></script>
 
 		<ClientRouter />
 	</head>

--- a/Frontend/urban-style/src/service/user.service.ts
+++ b/Frontend/urban-style/src/service/user.service.ts
@@ -107,6 +107,28 @@ async function changePassword(
 	return Success(responseData.message)
 }
 
+/**
+ * Deletes a user account.
+ * @param userId - The ID of the user to delete.
+ * @param reason - The reason for deleting the account.
+ * @returns A promise that resolves with a success message or an error message.
+ * @throws {ResponseException} If the request fails.
+ */
+async function deleteUser(userId: string, reason: string): Promise<Result<string, ErrorMessage>> {
+	const response = await axios.delete<Response<never>>(
+		`${PUBLIC_API_URL}/users/delete?user-id=${userId}&reason=${reason}`,
+		{ withCredentials: true },
+	)
+	const { status, data: responseData } = response
+
+	if (status !== 200) {
+		const { message } = obtainsError(response)
+		return Err(message)
+	}
+
+	return Success(responseData.message)
+}
+
 async function deleteAvatar(userId: string): Promise<Result<string, ErrorMessage>> {
 	const response = await axios.delete<Response<never>>(
 		`${PUBLIC_API_URL}/users/delete-avatar?user-id=${userId}`,
@@ -131,5 +153,6 @@ export const UserService = {
 	validatePassword,
 	changePassword,
 	changeAvatar,
+	deleteUser,
 	deleteAvatar,
 }


### PR DESCRIPTION
### Description

This pull request introduces a significant refactor of the user profile's security page and adds the critical functionality for account deletion. The primary goals of these changes are to improve code organization, enhance user experience, and provide users with more control over their data.

### Key Changes

-   **Security Page Refactor:**
    -   The main `UserSecurity` component has been streamlined.
    -   The logic for changing a password has been extracted into its own dedicated component, `ChangePasswordForm`, improving separation of concerns.

-   **Account Deletion Feature:**
    -   A new `DeleteAccount` section has been added to the user profile.
    -   Users can now request to delete their account.
    -   A confirmation dialog (`DeleteAccountDialog`) requires the user to enter their current password to prevent accidental deletion.
    -   The `UserService` has been updated with a `deleteUser` method to handle the API request.

-   **UI/UX Enhancements:**
    -   Improved the visual style of buttons and inputs for a more consistent and modern look.
    -   Added hover effects to interactive elements.

-   **Code Quality and Documentation:**
    -   Added TSDoc comments to all new and modified components, hooks, and services to improve code clarity and maintainability.
    -   Updated the ESLint configuration to properly handle TypeScript files, ensuring better code quality.

### How to Test

1.  Navigate to the user profile page.
2.  Go to the "Security" tab.
3.  Test the "Change Password" functionality.
4.  Test the "Delete Account" functionality:
    -   Click the "Delete Account" button.
    -   Enter an incorrect password to see the error message.
    -   Enter the correct password to enable the final "Delete" button.
    -   (Optional) Confirm deletion and verify that the user is redirected.